### PR TITLE
Fix repository visibility label in frontend

### DIFF
--- a/repsy-backend/src/main/java/io/repsy/os/shared/repo/dtos/RepoListInfo.java
+++ b/repsy-backend/src/main/java/io/repsy/os/shared/repo/dtos/RepoListInfo.java
@@ -20,4 +20,5 @@ import lombok.Builder;
 import org.jspecify.annotations.NonNull;
 
 @Builder
-public record RepoListInfo(@NonNull String name, long diskUsage, @NonNull Instant createdAt) {}
+public record RepoListInfo(
+    @NonNull String name, boolean privateRepo, long diskUsage, @NonNull Instant createdAt) {}


### PR DESCRIPTION
Fixes #10

Expose and use `privateRepo` so repository visibility is displayed correctly in the frontend.